### PR TITLE
Send buffered logs to Loggly after timeout

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,11 @@ bunyan-loggly changes
 
 Documentation of all changes to bunyan-loggly.
 
+v0.0.5
+------
+
+- added option to flush buffered logs after timeout
+
 v0.0.4
 ------
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,32 @@ logger.info({});	// will send to loggly
 logger.info({});	// won't send to loggly
 ```
 
+### Flush timeout
+
+When buffering, a timeout can be provided to force flushing the buffer after a period of time. To setup a flush timeout, pass a timeout value (in ms) as the thrid parameter when creating a new instance of Bunyan2Loggly:
+
+```javascript
+var bunyan = require('bunyan'),
+	Bunyan2Loggly = require('bunyan-loggly').Bunyan2Loggly,
+	logger;
+
+// create the logger
+logger = bunyan.createLogger({
+	name: 'logglylog',
+	streams: [
+		{
+			type: 'raw',
+			stream: new Bunyan2Loggly({
+				token: 'your-account-token',
+				subdomain: 'your-sub-domain'
+			}, 5, 250)
+		}
+	]
+});
+
+logger.info({});	// will be sent to loggly in 250ms if buffer threshold is not reached
+```
+
 Changes
 -------
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 
 var loggly = require('loggly'),
-	util = require('util');
+		util = require('util');
 
 function Bunyan2Loggly (logglyConfig, buffer, timeout) {
 
@@ -13,8 +13,8 @@ function Bunyan2Loggly (logglyConfig, buffer, timeout) {
 	this.buffer = buffer || 1;
 	this._buffer = [];
 
-  // define the buffer flush timeout
-  this.timeout = typeof timeout === 'number' && timeout > 0 ? timeout : 0;
+	// define the buffer flush timeout
+	this.timeout = typeof timeout === 'number' && timeout > 0 ? timeout : 0;
 
 	// add the https tag by default, just to make the loggly source setup work as expect
 	this.logglyConfig.tags = this.logglyConfig.tags || [];
@@ -50,13 +50,15 @@ Bunyan2Loggly.prototype.write = function(rec) {
 };
 
 Bunyan2Loggly.prototype.checkBuffer = function (force) {
-  if (!this._buffer.length) return;
-  this._timeout = clearTimeout(this._timeout);
+	if (!this._buffer.length) {
+		return;
+	}
+	this._timeout = clearTimeout(this._timeout);
 
 	if (this._buffer.length < this.buffer && !force) {
-    this._timeout = setTimeout(function(self) {
-      self.checkBuffer(true);    
-    }, this.timeout, this);
+		this._timeout = setTimeout(function(self) {
+			self.checkBuffer(true);
+		}, this.timeout, this);
 		return;
 	}
 


### PR DESCRIPTION
In cases of low log volume, it's possible to have logs live in the buffer for an extended period of time. I've added an additional parameter that defines a timeout (in ms) after which the buffered logs will automatically be sent to Loggly. The timeout is reset each time a log is created.

I added the timeout as an additional parameter, as opposed to accepting a buffering options object, for backwards compatibility.
