### PR TITLE
Fix tags issue

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,11 @@ bunyan-loggly changes
 
 Documentation of all changes to bunyan-loggly.
 
+v0.0.6
+------
+
+- fixed bug in v0.0.5 missing Loggly tags
+
 v0.0.4
 ------
 

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ Bunyan2Loggly.prototype.checkBuffer = function () {
 	this._buffer = [];
 
 	// log multiple (or single) requests with loggly
-	this.client.log(content);
+	this.client.log(content[0]);
 
 };
 

--- a/index.js
+++ b/index.js
@@ -57,7 +57,9 @@ Bunyan2Loggly.prototype.checkBuffer = function () {
 	this._buffer = [];
 
 	// log multiple (or single) requests with loggly
-	this.client.log(content[0]);
+	for (var i = 0; i < content.length; i++) {
+		this.client.log(content[i]);
+	}
 
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunyan-loggly",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A bunyan stream to transport logs to loggly",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
I found that if the entire content array is written to Loggly, the tags are not displayed. By writing each element of content separately, tags are preserved.
