### PR TITLE
When sending in bulk, send using the bulk endpoint (i.e. pass an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,9 +37,10 @@ Bunyan2Loggly.prototype._processBuffer = function(){
     var content = this._buffer.slice();
     this._buffer = [];
 
-    for (var i = 0; i < content.length; i++) {
-        this.logglyClient.log(content[i]);
+    if (content.length == 1) {
+        content = content[0];
     }
+    this.logglyClient.log(content);
 };
 
 Bunyan2Loggly.prototype._checkBuffer = function(){

--- a/tests/index.js
+++ b/tests/index.js
@@ -135,7 +135,7 @@ test('Bunyan2Loggly sends data to loggly', function (t) {
 });
 
 test('Bunyan2Loggly sends data to loggly once buffer limit is reached', function (t) {
-    t.plan(2);
+    t.plan(1);
     var mocks = getBaseMocks(),
         Bunyan2Loggly = proxyquire('../', mocks),
         testData = {foo: 'bar'},
@@ -147,7 +147,7 @@ test('Bunyan2Loggly sends data to loggly once buffer limit is reached', function
                 if(!sent){
                     t.fail('should not have sent until buffer limit reached');
                 }
-                t.deepEqual(data, testData, 'data sent to loggly');
+                t.deepEqual(data, [testData, testData], 'data sent to loggly');
             }
         };
     };


### PR DESCRIPTION
to loggly, not individual records).
