### PR TITLE
Upgraded dependency loggly -> node-loggly-bulk

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "json-stringify-safe": "^5.0.1",
-    "loggly": "^1.1.0"
+    "node-loggly-bulk": "^2.0.0"
   },
   "devDependencies": {
     "proxyquire": "^1.7.4",


### PR DESCRIPTION
As explained in #13 loggly package is unmaintained and a fork is available which solves several warnings.