### PR TITLE
Fix types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,8 @@ import * as logger from 'bunyan';
 
 export = BunyanLoggly;
 
-declare class BunyanLoggly implements logger.Stream {
+interface BunyanLoggly extends logger.WriteFn {}
+declare class BunyanLoggly {
     constructor(
         options: BunyanLoggly.IOptions,
         bufferLength?: number,


### PR DESCRIPTION
Possibly related: https://github.com/MauriceButler/bunyan-loggly/issues/36.

As we pass `Bunyan2Loggly` to the `stream` parameter of bunyan's `Stream` object, we need to pass there `NodeJS.WritableStream | WriteFn | undefined` type as defined in `bunyan` types, not the `Stream` instance itself.

This should fix the `Type 'BunyanLoggly' is not assignable to type 'WritableStream | WriteFn | undefined'.` error.